### PR TITLE
rename misnamed middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ if htmxRequest := htmxtools.RequestFromContext(r.Context()); htmxRequest != nil 
 
 ### Middleware
 ```go
-http.Handle("/", htmxtools.Middleware(mymux))
+http.Handle("/", htmxtools.Wrap(myhandler))
+```
+or
+```go
+http.Handle("/",htmxtools.WrapFunc(myhandlerfunc))
 ```
 
 This will detect htmx requests and inject the details into the context.

--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -32,7 +32,7 @@ func main() {
 	mux.HandleFunc("/alert", serversideAlert)
 	mux.HandleFunc("/button-push", buttonPush)
 	mux.HandleFunc("/", templateMiddleware)
-	middleware := htmxtools.Middleware(requestLogger(mux))
+	middleware := htmxtools.WrapFunc(requestLogger(mux))
 	if err := http.ListenAndServe(":3000", middleware); err != nil && err != http.ErrServerClosed {
 		panic(err)
 	}

--- a/middleware.go
+++ b/middleware.go
@@ -5,9 +5,8 @@ import (
 	"strings"
 )
 
-// Middleware parses an htmx request and injects any htmx metadata in the context
-// drop indicates if non-htmx requests should be dropped or not
-func Middleware(next http.Handler) http.HandlerFunc {
+// WrapFunc is middleware for inspecting http requests for htmx metadata
+func WrapFunc(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if res := ParseRequest(r); res != nil {
 			ctx := res.ToContext(r.Context())
@@ -16,6 +15,18 @@ func Middleware(next http.Handler) http.HandlerFunc {
 		}
 		next.ServeHTTP(w, r)
 	}
+}
+
+// Wrap is middleware for inspecting http requests for htmx metadata
+func Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if res := ParseRequest(r); res != nil {
+			ctx := res.ToContext(r.Context())
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // ParseRequest parses an [http.Request] for any htmx request headers and returns an [HTMXRequest]

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -75,7 +75,7 @@ func TestMiddleware(t *testing.T) {
 	testHandlerFunc := func(w http.ResponseWriter, r *http.Request) {
 		extractedRequest = RequestFromContext(r.Context())
 	}
-	server := httptest.NewServer(Middleware(http.HandlerFunc(testHandlerFunc)))
+	server := httptest.NewServer(WrapFunc(testHandlerFunc))
 	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 	require.NoError(t, err, "new request should not error")
 	require.NotNil(t, req, "http request should not be nil")


### PR DESCRIPTION
I meant to do this previously.